### PR TITLE
Temporary fix for gfortran/10 compiler argument mismatches (#1251)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ all_wrfvar :
 	fi
 	if [ $(BUFR) ] ; then \
 	  (cd var/external/bufr;  \
-	  $(MAKE) $(J) FC="$(SFC)" CC="$(SCC)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" FFLAGS="$(FCOPTIM) $(FORMAT_FIXED)" RANLIB="$(RANLIB)" AR="$(AR)" ARFLAGS="$(ARFLAGS)" ) ; \
+	  $(MAKE) $(J) FC="$(SFC)" CC="$(SCC)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" FFLAGS="$(FCOPTIM) $(FORMAT_FIXED) $(FCCOMPAT)" RANLIB="$(RANLIB)" AR="$(AR)" ARFLAGS="$(ARFLAGS)" ) ; \
 	fi
 ### Use 'make' to avoid '-i -r' above:
 	if [ $(WAVELET) ] ; then \

--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -73,8 +73,9 @@ FCDEBUG         =       # -g $(FCNOOPT)  # -fbacktrace -ggdb -fcheck=bounds,do,m
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
 TRADFLAG        =      CONFIGURE_TRADFLAG
@@ -785,8 +786,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -ggdb -fbacktrace -fcheck=bounds,do,me
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =     
 TRADFLAG        =      CONFIGURE_TRADFLAG
@@ -1006,8 +1008,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -fbacktrace -ggdb -fcheck=bounds,do,me
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
 TRADFLAG        =      CONFIGURE_TRADFLAG
@@ -1049,8 +1052,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -fbacktrace -ggdb -fcheck=bounds,do,me
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
 TRADFLAG        =      CONFIGURE_TRADFLAG
@@ -1772,8 +1776,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -fbacktrace -ggdb -fcheck=bounds,do,me
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =
 TRADFLAG        =      CONFIGURE_TRADFLAG
@@ -1946,8 +1951,9 @@ FCDEBUG         =       # -g $(FCNOOPT) # -ggdb -fbacktrace
 FORMAT_FIXED    =       -ffixed-form
 FORMAT_FREE     =       -ffree-form -ffree-line-length-none
 FCSUFFIX        =       
+FCCOMPAT        =       
 BYTESWAPIO      =       -fconvert=big-endian -frecord-marker=4
-FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO)
+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) $(FCCOMPAT)
 FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 MODULE_SRCH_FLAG =     
 TRADFLAG        =      -traditional

--- a/configure
+++ b/configure
@@ -685,6 +685,25 @@ if [ $os = "Linux" -o $os = "Darwin" ]; then
 
   foo=foo_$$
 
+  grep '^SFC' configure.wrf | grep -i 'gfortran' > /dev/null
+  if [ $? ]
+  then
+
+    cat > ${foo}.F << EOF
+      PROGRAM GFORTRAN_VERSION_CHECK
+        IF (__GNUC__ .GT. 9) CALL EXIT(1)
+      END PROGRAM
+EOF
+
+    gfortran -o ${foo} ${foo}.F > /dev/null 2>&1 && ./${foo}
+    if [ $? -eq 1 ]
+    then
+      sed '/^FCCOMPAT/ s/$/ -fallow-argument-mismatch -fallow-invalid-boz/' configure.wrf > configure.wrf.edit
+      mv configure.wrf.edit configure.wrf
+    fi
+    rm ${foo} ${foo}.F 2> /dev/null
+  fi
+
 cat > ${foo}.c <<EOF 
  int main(int argc, char ** argv)
  {


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: gfortran/10

SOURCE: Srikanth Yalavarthi (Marvell Semiconductor)

DESCRIPTION OF CHANGES: 
Problem:
Due to argument inconsistencies, the WRF code will not compile with gfortran/10. 

Here are some examples of incorrect Fortran argument usages:

```
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
wrf_io.f:7605:71:

 7605 |                                                    ,i1,i2,j1,j2,k1,k2 )
      |                                                                       1
```
```
Error: Type mismatch in argument ‘field’ at (1); passed INTEGER(4) to REAL(8)
wrf_io.f:7744:49:

 2538 |     stat = NF_GET_ATT_INT (DH%NCID,NF_GLOBAL,Element,Buffer)
      |                                                     2
......
 7744 |     stat = NF_GET_ATT_INT(NCID,VarID,'FieldType',FType)
      |                                                 1
```
```
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-3)
field_routines.f:158:52:

  110 |     stat = NF_GET_VARA_INT(NCID,VarID,VStart,VCount,Data)
      |                                                    2
......
  158 |     stat = NF_GET_VARA_INT(NCID,VarID,VStart,VCount,Buffer)
      |                                                    1
```
```
Error: Rank mismatch in argument ‘fileindex’ at (1) (scalar and rank-1)
io_grib1.f90:685:27:

  685 |   CALL gr1_fill_eta_levels(fileinfo(DataHandle)%fileindex(:), FileFd(DataHandle), &
      |                           1
```
```
Error: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/REAL(4)).
module_internal_header_util.f:1592:39:

 1592 |                            DataHandle, Data, Count, code )
      |                                       1
......
 1654 |                            DataHandle, Data, Count, code )
      |                                       2
```
```
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
module_io_int_read.f:129:39:

  129 |     call mpi_file_read_at(ifd, offset, tmp, 1, &
      |                                       1
......
  573 |     call mpi_file_read_at(ifd, offset, tmp, num, &
      |                                       2
```
```
Error: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(8)/COMPLEX(8)).
zmfm1b.f90:74:38:

   72 |       call zmf3kb ( lot, ido, l1, na, c, jump, inc, ch, 1, lot, wa(iw) )
      |                                      2
   73 |     else if ( nbr == 4 ) then
   74 |       call zmf3kb ( lot, ido, l1, na, ch, 1, lot, c, jump, inc, wa(iw) )
      |                                      1
```
The errors in the WRF infrastructure code can be eventually updated. However, the code from the FFTPACK library 
will be left AS-IS. We are going to initially address all of the problems in a temporary fashion.

Temporary solution:
A compiler flag was added for the gfortran compiler to allow mismatched arguments, which enables the WRF system
to build. The new flag is only for versions of gfortran 10 and later. This change was introduced in the configure script,
which modifies all gfortran stanzas.

Permanent fix:
A complete fix requires changes in the Fortran sources for BOZ declarations and to fix mismatches in subroutine 
arguments.

ISSUE: 
Fixes #1250

LIST OF MODIFIED FILES: 
M   Makefile
M   arch/configure.defaults
M   configure

TESTS CONDUCTED: 
1. Successfully built the master branch with GCC-10 on RPi4 Ubuntu-20.04 machine
2. Logic tested, where only GNU 10 and above are impacted.
3. Other compilers are not affected.
4. Jenkins testing is OK.
5. The DA variants have been tested also:  I could build WRF / WRFPLUS / 3DVAR / 4DVAR
```
[00:01] [syalavarthi@sparrow WRF]$./configure wrfda && ./compile all_wrfvar && ls var/build/*.exe
var/build/da_advance_time.exe         var/build/da_tune_obs_hollingsworth1.exe  var/build/gen_be_addmean.exe                var/build/gen_be_diags.exe       var/build/gen_be_hist.exe          var/build/gen_be_stage2_1dvar.exe     var/build/gen_mbe_stage2.exe
var/build/da_bias_airmass.exe         var/build/da_tune_obs_hollingsworth2.exe  var/build/gen_be_cov2d.exe                  var/build/gen_be_diags_read.exe  var/build/gen_be_stage0_gsi.exe    var/build/gen_be_stage2_gsi.exe
var/build/da_bias_scan.exe            var/build/da_update_bc.exe                var/build/gen_be_cov2d3d_contrib.exe        var/build/gen_be_ensmean.exe     var/build/gen_be_stage0_wrf.exe    var/build/gen_be_stage2a.exe
var/build/da_bias_sele.exe            var/build/da_update_bc_ad.exe             var/build/gen_be_cov3d.exe                  var/build/gen_be_ensrf.exe       var/build/gen_be_stage1.exe        var/build/gen_be_stage3.exe
var/build/da_bias_verif.exe           var/build/da_verif_grid.exe               var/build/gen_be_cov3d2d_contrib.exe        var/build/gen_be_ep1.exe         var/build/gen_be_stage1_1dvar.exe  var/build/gen_be_stage4_global.exe
var/build/da_rad_diags.exe            var/build/da_verif_obs.exe                var/build/gen_be_cov3d3d_bin3d_contrib.exe  var/build/gen_be_ep2.exe         var/build/gen_be_stage1_gsi.exe    var/build/gen_be_stage4_regional.exe
var/build/da_tune_obs_desroziers.exe  var/build/da_wrfvar.exe                   var/build/gen_be_cov3d3d_contrib.exe        var/build/gen_be_etkf.exe        var/build/gen_be_stage2.exe        var/build/gen_be_vertloc.exe
[00:10] [syalavarthi@sparrow WRF]$

[06:40] [syalavarthi@sparrow WRFPLUS]$./configure wrfplus && ./compile wrfplus && ls main/*.exe
main/wrfplus.exe

[07:16] [syalavarthi@sparrow WRF]$./configure 4dvar && ./compile all_wrfvar && ls var/build/*.exe
var/build/da_advance_time.exe         var/build/da_tune_obs_hollingsworth1.exe  var/build/gen_be_addmean.exe                var/build/gen_be_diags.exe       var/build/gen_be_hist.exe          var/build/gen_be_stage2_1dvar.exe     var/build/gen_mbe_stage2.exe
var/build/da_bias_airmass.exe         var/build/da_tune_obs_hollingsworth2.exe  var/build/gen_be_cov2d.exe                  var/build/gen_be_diags_read.exe  var/build/gen_be_stage0_gsi.exe    var/build/gen_be_stage2_gsi.exe
var/build/da_bias_scan.exe            var/build/da_update_bc.exe                var/build/gen_be_cov2d3d_contrib.exe        var/build/gen_be_ensmean.exe     var/build/gen_be_stage0_wrf.exe    var/build/gen_be_stage2a.exe
var/build/da_bias_sele.exe            var/build/da_update_bc_ad.exe             var/build/gen_be_cov3d.exe                  var/build/gen_be_ensrf.exe       var/build/gen_be_stage1.exe        var/build/gen_be_stage3.exe
var/build/da_bias_verif.exe           var/build/da_verif_grid.exe               var/build/gen_be_cov3d2d_contrib.exe        var/build/gen_be_ep1.exe         var/build/gen_be_stage1_1dvar.exe  var/build/gen_be_stage4_global.exe
var/build/da_rad_diags.exe            var/build/da_verif_obs.exe                var/build/gen_be_cov3d3d_bin3d_contrib.exe  var/build/gen_be_ep2.exe         var/build/gen_be_stage1_gsi.exe    var/build/gen_be_stage4_regional.exe
var/build/da_tune_obs_desroziers.exe  var/build/da_wrfvar.exe                   var/build/gen_be_cov3d3d_contrib.exe        var/build/gen_be_etkf.exe        var/build/gen_be_stage2.exe        var/build/gen_be_vertloc.exe
```

RELEASE NOTE: Due to subroutine and function argument inconsistencies, the WRF code will not compile with gfortran/10.  The fix introduces a new compiler flag for all gfortran stanzas (`-fallow-argument-mismatch -fallow-invalid-boz`).

Use this template to give a detailed message describing the change you want to make to the code.
If you are unclear on what should be written here, see  https://github.com/wrf-model/WRF/wiki/Making-a-good-pull-request-message for more guidance

The title of this pull request should be a brief "purpose" for this change.

--- Delete this line and those above before hitting "Create pull request" ---

TYPE: choose one of [bug fix, enhancement, new feature, feature removed, no impact, text only]

KEYWORDS: approximately 3 to 6 words (more is always better) related to your commit, separated by commas

SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev committee member

DESCRIPTION OF CHANGES: One or more paragraphs describing problem, solution, and required changes.

ISSUE: For use when this PR closes an issue. For example, if this PR closes issue number 123
Fixes #123

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

TESTS CONDUCTED: Explicitly state if a WTF and or other tests were run, or are pending. For more complicated changes please be explicit!

RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.
